### PR TITLE
use a nested path in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ export async function defineConfig(env) {
     referenceLanguage: "en",
     plugins: [
       jsonPlugin({
-        pathPattern: "./{language}.json",
+        pathPattern: "./resources/{language}.json",
       })
     ]
   };
@@ -48,7 +48,7 @@ type PluginSettings = {
 ### `pathPattern`
 
 To use our plugin, you need to provide a path to the directory where your language-specific files are stored. Use the dynamic path syntax `{language}` to specify the language name. Note that subfile structures are not supported.
- 
+
 **Type definition**
 ```typescript
 pathPattern: string;
@@ -56,7 +56,7 @@ pathPattern: string;
 
 **Example**
 ```typescript
-pathPattern: "./{language}.json"
+pathPattern: "./resources/{language}.json"
 ```
 
 

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -17,6 +17,6 @@ it("should throw if the path pattern does not include the {language} placeholder
 it("should not throw if the path pattern is valid", async () => {
   const env = await mockEnvironment({});
   await env.$fs.writeFile("./resources/en.json", "{}");
-  const x = plugin({ pathPattern: "./{language}.json" })(env);
+  const x = plugin({ pathPattern: "./resources/{language}.json" })(env);
   expect(await x.config({})).toBeTruthy();
 });


### PR DESCRIPTION
People will use the default and wonder why `package.json` shows up in their languages ^^